### PR TITLE
Update setup-credentials.md

### DIFF
--- a/doc_source/setup-credentials.md
+++ b/doc_source/setup-credentials.md
@@ -92,7 +92,7 @@ To complete this procedure, you must first have the additional [access key](http
    For example, for a named profile named `myuser`, use the following format\.
 
    ```
-   [profile myuser]
+   [myuser]
    aws_access_key_id = AKIAIOSFODNN7EXAMPLE
    aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
    ```


### PR DESCRIPTION
[profile ABC] is not the correct way, but it works with me with simply `[ABC]`

*Issue #, if available:*

*Description of changes:*
The documentation of adding a new profile in `credentials` seems to be incorrect. There is no need to add "profile" as a string before the actual profile name.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
