### PR TITLE
Update IntelliJ IDEA name

### DIFF
--- a/doc_source/welcome.md
+++ b/doc_source/welcome.md
@@ -20,7 +20,7 @@ The AWS Toolkit for JetBrains is an open source plugin for the integrated develo
 The AWS Toolkit for JetBrains includes the following specific toolkits:
 +  AWS Toolkit for [CLion](https://www.jetbrains.com/clion/) \(for C & C\+\+ development\)
 +  AWS Toolkit for [GoLand](https://www.jetbrains.com/go/) \(for Go development\)
-+  AWS Toolkit for [IntelliJ](https://aws.amazon.com/intellij/) \(for Java development\)
++  AWS Toolkit for [IntelliJ IDEA](https://aws.amazon.com/intellij/) \(for Java development\)
 + AWS Toolkit for [WebStorm](https://aws.amazon.com/webstorm/) \(for Node\.js development\)
 + AWS Toolkit for [Rider](https://aws.amazon.com/rider/) \(for \.NET development\)
 + AWS Toolkit for [PhpStorm ](https://www.jetbrains.com/php/) \(for PHP development\)


### PR DESCRIPTION
Hi guys, just a small fix. When speaking about our IDE for Java, we usually call it "IntelliJ IDEA". IntelliJ is rather a name for the platform used to build all these IDEs.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
